### PR TITLE
fix: Support nested controller class

### DIFF
--- a/lib/tidy_strong_params/resource.rb
+++ b/lib/tidy_strong_params/resource.rb
@@ -7,7 +7,7 @@ module TidyStrongParams
     end
 
     def name
-      resource.underscore
+      resource.split('::').last.underscore
     end
 
     def strong_params_class

--- a/spec/fixtures/controllers/example_module/examples_controller.rb
+++ b/spec/fixtures/controllers/example_module/examples_controller.rb
@@ -1,0 +1,4 @@
+module ExampleModule
+  class ExamplesController < ActionController::Base
+  end
+end

--- a/spec/fixtures/params/example_module/example_strong_params.rb
+++ b/spec/fixtures/params/example_module/example_strong_params.rb
@@ -1,0 +1,5 @@
+module ExampleModule
+  class ExampleStrongParams < TidyStrongParams::StrongParams
+    params :example_param
+  end
+end

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'fixtures/params/original_gangster_strong_params'
+require 'fixtures/params/example_module/example_strong_params'
 
 RSpec.describe TidyStrongParams::Resource do
   let(:controller_class) { 'OriginalGangstersController' }
@@ -7,6 +8,13 @@ RSpec.describe TidyStrongParams::Resource do
 
   it 'returns a name' do
     expect(subject.name).to eq('original_gangster')
+  end
+
+  context 'with a nested module' do
+    let(:controller_class) { 'ExampleModule::ExamplesController' }
+    it 'returns a non-nested name' do
+      expect(subject.name).to eq('example')
+    end
   end
 
   describe '#strong_params_class' do


### PR DESCRIPTION
This PR adds a small change to `resource#name` so that it will ignore any modules when determining the `name` property. Previously, if your controller and params definition were under a module, e.g. `My::Module::SomeController`, by default `tidy_strong_params` would require the key `my/module/some` instead of just `some`.

Being able to nest under modules is useful if you've got controllers that share the same name for different purposes, e.g. `PublicApi::FilesController` and `PrivateApi::FilesController` but still want both to accept `{ file: { name: "" }}`

The PR also adds a simple test for the new behaviour. All feedback welcome, of course.